### PR TITLE
fix(docker): copy pnpm-workspace.yaml to deps stage for native module builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 
 # ---- Dependencies --------------------------------------------------------
 FROM base AS deps
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

The pnpm 8→10 upgrade (PR #27) introduced `pnpm-workspace.yaml` with `onlyBuiltDependencies` config for native modules. However, the Dockerfile's deps stage only copies `package.json` and `pnpm-lock.yaml` — it doesn't copy `pnpm-workspace.yaml`. This means `pnpm install --frozen-lockfile` skips the `better-sqlite3` build script, leaving the native `.node` binding missing from the Docker image.

### Impact

This caused **all CMS-driven pages (blog, about, etc.) to render empty** on production after the PR #27 deploy. The EmDash CMS couldn't read from the SQLite database, showing `0 articles` on the blog and an empty about page.

### Root cause

```dockerfile
# Before (broken)
COPY package.json pnpm-lock.yaml ./
RUN pnpm install --frozen-lockfile
# → better-sqlite3 build script skipped, no .node binding compiled

# After (fixed)
COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
RUN pnpm install --frozen-lockfile
# → pnpm reads onlyBuiltDependencies, compiles better-sqlite3
```

### Verification

Confirmed on the live server:
- The broken image (`cec98b5cc257`) has missing `better_sqlite3.node`
- A patched image with the binding pre-built restores all CMS content immediately
- Blog page goes from `0 articles` to `4 articles`
- About page goes from empty to full content with sections